### PR TITLE
Fix demo for Unity 2019.3+

### DIFF
--- a/Demo/KnnVisualizationDemo.cs
+++ b/Demo/KnnVisualizationDemo.cs
@@ -4,7 +4,7 @@ using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
 using UnityEngine;
-using UnityEngine.Experimental.ParticleSystemJobs;
+using UnityEngine.ParticleSystemJobs;
 
 // Ideally you really would use something like ECS to visualize the point cloud
 // And query from a job component system
@@ -58,14 +58,14 @@ public class KnnVisualizationDemo : MonoBehaviour {
 	}
 
 	// [BurstCompile(CompileSynchronously = true)]
-	struct ParticleJob : IParticleSystemJob {
+	struct ParticleJob : IJobParticleSystem {
 		[ReadOnly] public NativeArray<int> KnnResults;
 		public NativeArray<float3> Points;
 
 		public NativeArray<Color32> Colors;
 		public int K;
 
-		public void ProcessParticleSystem(ParticleSystemJobData jobData) {
+		public void Execute(ParticleSystemJobData jobData) {
 			var colors = jobData.startColors;
 			var positions = jobData.positions;
 
@@ -85,13 +85,13 @@ public class KnnVisualizationDemo : MonoBehaviour {
 		}
 	}
 
-	struct ParticleRangeJob : IParticleSystemJob {
+	struct ParticleRangeJob : IJobParticleSystem {
 		[ReadOnly] public NativeArray<RangeQueryResult> KnnResults;
 
 		public NativeArray<float3> Points;
 		public NativeArray<Color32> Colors;
 
-		public void ProcessParticleSystem(ParticleSystemJobData jobData) {
+		public void Execute(ParticleSystemJobData jobData) {
 			var partColors = jobData.startColors;
 			var partPos = jobData.positions;
 
@@ -119,20 +119,20 @@ public class KnnVisualizationDemo : MonoBehaviour {
 	void Update() {
 		if (Mode == QueryMode.KNearest) {
 			// Update particles job to do the colors
-			m_system.SetJob(new ParticleJob {
+			new ParticleJob {
 				KnnResults = m_results,
 				Points = m_points,
 				K = QueryK,
 				Colors = m_queryColors
-			});
+			}.Schedule(m_system);
 		}
 		else {
 			// Update particles job to do the colors
-			m_system.SetJob(new ParticleRangeJob {
+			new ParticleRangeJob {
 				KnnResults = m_rangeResults,
 				Points = m_points,
 				Colors = m_queryColors
-			});
+			}.Schedule(m_system);
 		}
 	}
 


### PR DESCRIPTION
The `IParticleSystemJob` was moved out of experimental namespace and renamed to `IJobParticleSystem` in Unity 2019.3+ (with slightly different syntax)